### PR TITLE
Add agent graph domain model and Graphviz parser

### DIFF
--- a/docs/AgentSpecification.md
+++ b/docs/AgentSpecification.md
@@ -1,0 +1,68 @@
+# Agent Specification
+
+This document describes the specification for the Agent Graph used by the
+scalable agent framework.
+
+## Overview
+
+An **AgentGraph** describes how plans and tasks coordinate with each other.
+The specification of a graph is provided in a JSON, YAML or Graphviz `dot`
+file that resides in a directory.  Each graph directory contains two
+sub‑directories:
+
+* `plans/` – python mini projects that implement individual plans.
+* `tasks/` – python mini projects that implement individual tasks.
+
+The graph specifier and the `plans/` and `tasks/` directories are siblings.
+
+## Plans
+
+* Each plan has a unique `name`.
+* `plan_source` points to the directory under `plans/` containing the
+  python project.  A plan project contains a `plan.py` file exposing an entry
+  point:
+
+  ```python
+  def plan(upstreamResults: TaskResults[]) -> PlanResult:
+      ...
+  ```
+* Each project includes a `requirements.txt` declaring dependencies.
+* A plan can have multiple downstream tasks.
+* Plans maintain a list of task names that feed into them called
+  `upstream_task_ids`.
+
+## Tasks
+
+* Each task has a unique `name`.
+* `task_source` points to the directory under `tasks/` containing the python
+  project.  A task project contains a `task.py` file exposing an entry point:
+
+  ```python
+  def execute(upstreamPlan: PlanResults) -> PlanResult:
+      ...
+  ```
+* Each project includes a `requirements.txt` declaring dependencies.
+* A task has exactly one upstream plan.
+
+## Graph Structure
+
+* `AgentGraph` contains:
+  * a list of `Plan` instances
+  * a list of `Task` instances
+  * a map of edges `Plan.name -> List<Task.name>` representing downstream
+    tasks
+  * a map of edges `Task.name -> Plan.name` representing the single upstream
+    plan for a task
+* Parsers validate the graph by ensuring:
+  * all plans and tasks are connected by at least one edge
+  * tasks reference exactly one upstream plan
+  * edges reference existing plans and tasks
+* Cycles are allowed.
+
+## Parsers
+
+The framework supports pluggable parsers.  The initial implementation uses a
+Graphviz `dot` parser (via `org.graphper:graph-support-dot`).  Parsers read a
+specifier file and construct the `AgentGraph` along with its `Plan` and `Task`
+objects.
+

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>services/control_plane-java</module>
         <module>services/task_executor-java</module>
         <module>services/plan_executor-java</module>
+        <module>services/graph_builder-java</module>
     </modules>
     
     <dependencyManagement>

--- a/services/common-java/src/main/java/com/pcallahan/agentic/common/graph/AgentGraph.java
+++ b/services/common-java/src/main/java/com/pcallahan/agentic/common/graph/AgentGraph.java
@@ -1,0 +1,40 @@
+package com.pcallahan.agentic.common.graph;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Immutable representation of an agent graph containing plans, tasks and edges
+ * between them.
+ */
+public final class AgentGraph {
+    private final List<Plan> plans;
+    private final List<Task> tasks;
+    private final Map<String, List<String>> planToTasks;
+    private final Map<String, String> taskToPlan;
+
+    public AgentGraph(List<Plan> plans, List<Task> tasks,
+                      Map<String, List<String>> planToTasks,
+                      Map<String, String> taskToPlan) {
+        this.plans = List.copyOf(plans);
+        this.tasks = List.copyOf(tasks);
+        this.planToTasks = Map.copyOf(planToTasks);
+        this.taskToPlan = Map.copyOf(taskToPlan);
+    }
+
+    public List<Plan> getPlans() {
+        return plans;
+    }
+
+    public List<Task> getTasks() {
+        return tasks;
+    }
+
+    public Map<String, List<String>> getPlanToTasks() {
+        return planToTasks;
+    }
+
+    public Map<String, String> getTaskToPlan() {
+        return taskToPlan;
+    }
+}

--- a/services/common-java/src/main/java/com/pcallahan/agentic/common/graph/Plan.java
+++ b/services/common-java/src/main/java/com/pcallahan/agentic/common/graph/Plan.java
@@ -1,0 +1,16 @@
+package com.pcallahan.agentic.common.graph;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Representation of a plan within an agent graph.
+ */
+public record Plan(String name, Path planSource, List<String> upstreamTaskIds) {
+    public Plan {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(planSource, "planSource");
+        upstreamTaskIds = upstreamTaskIds == null ? List.of() : List.copyOf(upstreamTaskIds);
+    }
+}

--- a/services/common-java/src/main/java/com/pcallahan/agentic/common/graph/Task.java
+++ b/services/common-java/src/main/java/com/pcallahan/agentic/common/graph/Task.java
@@ -1,0 +1,15 @@
+package com.pcallahan.agentic.common.graph;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Representation of a task within an agent graph.
+ */
+public record Task(String name, Path taskSource, String upstreamPlanId) {
+    public Task {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(taskSource, "taskSource");
+        Objects.requireNonNull(upstreamPlanId, "upstreamPlanId");
+    }
+}

--- a/services/graph_builder-java/pom.xml
+++ b/services/graph_builder-java/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.pcallahan.agentic</groupId>
+        <artifactId>scalable-agent-framework</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>graph_builder-java</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Agentic Graph Builder Java</name>
+    <description>Parses agent graph specifications</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.pcallahan.agentic</groupId>
+            <artifactId>common-java</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.graphper</groupId>
+            <artifactId>graph-support-dot</artifactId>
+            <version>1.5.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/services/graph_builder-java/src/main/java/com/pcallahan/agentic/graphbuilder/GraphParseException.java
+++ b/services/graph_builder-java/src/main/java/com/pcallahan/agentic/graphbuilder/GraphParseException.java
@@ -1,0 +1,14 @@
+package com.pcallahan.agentic.graphbuilder;
+
+/**
+ * Exception thrown when a graph specification cannot be parsed.
+ */
+public class GraphParseException extends RuntimeException {
+    public GraphParseException(String message) {
+        super(message);
+    }
+
+    public GraphParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/graph_builder-java/src/main/java/com/pcallahan/agentic/graphbuilder/GraphParser.java
+++ b/services/graph_builder-java/src/main/java/com/pcallahan/agentic/graphbuilder/GraphParser.java
@@ -1,0 +1,12 @@
+package com.pcallahan.agentic.graphbuilder;
+
+import com.pcallahan.agentic.common.graph.AgentGraph;
+
+import java.nio.file.Path;
+
+/**
+ * Parses a graph specification into an {@link AgentGraph}.
+ */
+public interface GraphParser {
+    AgentGraph parse(Path specFile) throws GraphParseException;
+}

--- a/services/graph_builder-java/src/main/java/com/pcallahan/agentic/graphbuilder/GraphvizGraphParser.java
+++ b/services/graph_builder-java/src/main/java/com/pcallahan/agentic/graphbuilder/GraphvizGraphParser.java
@@ -1,0 +1,96 @@
+package com.pcallahan.agentic.graphbuilder;
+
+import com.pcallahan.agentic.common.graph.AgentGraph;
+import com.pcallahan.agentic.common.graph.Plan;
+import com.pcallahan.agentic.common.graph.Task;
+import org.graphper.parser.DotParser;
+import org.graphper.api.Graphviz;
+import org.graphper.api.Node;
+import org.graphper.api.Edge;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Graph parser implementation backed by Graphviz dot files.
+ */
+public class GraphvizGraphParser implements GraphParser {
+    @Override
+    public AgentGraph parse(Path specFile) throws GraphParseException {
+        Graphviz graph;
+        try {
+            graph = DotParser.parse(Files.newBufferedReader(specFile));
+        } catch (IOException e) {
+            throw new GraphParseException("Failed to read spec file", e);
+        }
+
+        Map<String, Path> planSources = new HashMap<>();
+        Map<String, Path> taskSources = new HashMap<>();
+
+        for (Node node : graph.nodes()) {
+            String id = node.id();
+            String type = node.get("type");
+            if ("plan".equals(type)) {
+                String src = node.get("plan_source");
+                planSources.put(id, specFile.getParent().resolve(src));
+            } else if ("task".equals(type)) {
+                String src = node.get("task_source");
+                taskSources.put(id, specFile.getParent().resolve(src));
+            } else {
+                throw new GraphParseException("Unknown node type for " + id);
+            }
+        }
+
+        Map<String, List<String>> planToTasks = new HashMap<>();
+        Map<String, String> taskToPlan = new HashMap<>();
+
+        for (Edge edge : graph.edges()) {
+            String from = edge.from().id();
+            String to = edge.to().id();
+            if (planSources.containsKey(from) && taskSources.containsKey(to)) {
+                planToTasks.computeIfAbsent(from, k -> new ArrayList<>()).add(to);
+                if (taskToPlan.put(to, from) != null) {
+                    throw new GraphParseException("Task " + to + " has multiple upstream plans");
+                }
+            } else if (taskSources.containsKey(from) && planSources.containsKey(to)) {
+                if (taskToPlan.put(from, to) != null) {
+                    throw new GraphParseException("Task " + from + " points to multiple plans");
+                }
+                planToTasks.computeIfAbsent(to, k -> new ArrayList<>());
+            } else {
+                throw new GraphParseException("Edges must connect plans and tasks");
+            }
+        }
+
+        Map<String, List<String>> upstreamTasksByPlan = new HashMap<>();
+        for (Map.Entry<String, String> entry : taskToPlan.entrySet()) {
+            upstreamTasksByPlan.computeIfAbsent(entry.getValue(), k -> new ArrayList<>()).add(entry.getKey());
+        }
+
+        List<Task> tasks = new ArrayList<>();
+        for (Map.Entry<String, Path> e : taskSources.entrySet()) {
+            String upstream = taskToPlan.get(e.getKey());
+            if (upstream == null) {
+                throw new GraphParseException("Task " + e.getKey() + " is unconnected");
+            }
+            tasks.add(new Task(e.getKey(), e.getValue(), upstream));
+        }
+
+        List<Plan> plans = new ArrayList<>();
+        for (Map.Entry<String, Path> e : planSources.entrySet()) {
+            List<String> upstream = upstreamTasksByPlan.getOrDefault(e.getKey(), List.of());
+            if (!planToTasks.containsKey(e.getKey()) && upstream.isEmpty()) {
+                throw new GraphParseException("Plan " + e.getKey() + " is unconnected");
+            }
+            planToTasks.putIfAbsent(e.getKey(), new ArrayList<>());
+            plans.add(new Plan(e.getKey(), e.getValue(), upstream));
+        }
+
+        return new AgentGraph(plans, tasks, planToTasks, taskToPlan);
+    }
+}

--- a/services/graph_builder-java/src/test/java/com/pcallahan/agentic/graphbuilder/GraphvizGraphParserTest.java
+++ b/services/graph_builder-java/src/test/java/com/pcallahan/agentic/graphbuilder/GraphvizGraphParserTest.java
@@ -1,0 +1,52 @@
+package com.pcallahan.agentic.graphbuilder;
+
+import com.pcallahan.agentic.common.graph.AgentGraph;
+import com.pcallahan.agentic.common.graph.Plan;
+import com.pcallahan.agentic.common.graph.Task;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GraphvizGraphParserTest {
+
+    @Test
+    void parsesValidGraph() throws Exception {
+        String dot = "digraph{\n" +
+                "plan1 [type=\"plan\" plan_source=\"plans/plan1\"]\n" +
+                "plan2 [type=\"plan\" plan_source=\"plans/plan2\"]\n" +
+                "task1 [type=\"task\" task_source=\"tasks/task1\"]\n" +
+                "task2 [type=\"task\" task_source=\"tasks/task2\"]\n" +
+                "plan1 -> task1\n" +
+                "plan1 -> task2\n" +
+                "task1 -> plan2\n" +
+                "task2 -> plan2\n" +
+                "}";
+        Path tmp = Files.createTempFile("graph", ".dot");
+        Files.writeString(tmp, dot);
+
+        GraphParser parser = new GraphvizGraphParser();
+        AgentGraph graph = parser.parse(tmp);
+
+        assertEquals(2, graph.getPlans().size());
+        assertEquals(2, graph.getTasks().size());
+        assertEquals(List.of("task1", "task2"), graph.getPlanToTasks().get("plan1"));
+        assertEquals("plan1", graph.getTaskToPlan().get("task1"));
+
+        Plan plan2 = graph.getPlans().stream().filter(p -> p.name().equals("plan2")).findFirst().orElseThrow();
+        assertEquals(List.of("task1", "task2"), plan2.upstreamTaskIds());
+    }
+
+    @Test
+    void failsOnUnconnectedPlan() throws Exception {
+        String dot = "digraph{ plan1 [type=\"plan\" plan_source=\"plans/p1\"] }";
+        Path tmp = Files.createTempFile("bad", ".dot");
+        Files.writeString(tmp, dot);
+
+        GraphParser parser = new GraphvizGraphParser();
+        assertThrows(GraphParseException.class, () -> parser.parse(tmp));
+    }
+}


### PR DESCRIPTION
## Summary
- document agent graph specification
- add Plan, Task and AgentGraph objects in common-java
- introduce graph_builder-java service with a pluggable Graphviz parser and tests

## Testing
- `mvn -q -pl services/graph_builder-java,services/common-java -am test` *(fails: Non-resolvable parent POM for com.pcallahan.agentic:scalable-agent-framework:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_689009bb091c8321aea6e6d79750dc25